### PR TITLE
Read output of sub-process as string instead of bytes

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -96,7 +96,8 @@ def UpdateRosWorkspace():
         ROS_WORKSPACE_FLAGS = None
         try:
             ROS_WORKSPACE = subprocess.check_output(['catkin', 'locate'],
-                                                    stderr=subprocess.STDOUT).strip()
+                                                    stderr=subprocess.STDOUT,
+                                                    universal_newlines=True).strip()
         except subprocess.CalledProcessError as e:
             if e.returncode == 1:
                 LOGGER.info('catkin locate error: %s', result.output)


### PR DESCRIPTION
Hi,

I tried on ROS Noetic (Ubuntu 20.04), and it seems that in Python 3, the sub-process retrieving `ROS_WORKSPACE` outputs bytes instead of a string. Apparently, setting `universal_newlines` to `True` in `check_output` fixes the problem, and in Python 3, this flag is provided as an alias of `text' for backward compatibility, but I haven't tested with other versions than Python 3.8.2.

Thanks a lot,
David